### PR TITLE
feat: connect chat to UnderstandTech API

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -2,6 +2,6 @@ FROM python:3.11-slim
 WORKDIR /app
 COPY ./src/api /app/api
 COPY ./src/core /app/core
-RUN pip install fastapi uvicorn
+RUN pip install fastapi uvicorn requests
 EXPOSE 8000
 CMD ["uvicorn", "api.routes:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - "8000"
     environment:
       - API_KEY=c77c0acb-9aa7-4eae-a18a-482be1019d15
+      - UNDERSTANDTECH_API_URL=https://api.understandtech.com/chat
   frontend:
     build:
       context: ./frontend

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -2,6 +2,8 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from typing import List
+import os
+import requests
 
 app = FastAPI()
 
@@ -12,6 +14,9 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+API_KEY = os.getenv("API_KEY")
+API_URL = os.getenv("UNDERSTANDTECH_API_URL", "https://api.understandtech.com/chat")
 
 messages = []
 
@@ -26,4 +31,20 @@ def get_messages():
 @app.post("/api/messages")
 def post_message(msg: Message):
     messages.append(msg)
-    return {"status": "ok"}
+
+    try:
+        headers = {"Authorization": f"Bearer {API_KEY}"} if API_KEY else {}
+        response = requests.post(
+            API_URL,
+            json={"message": msg.content},
+            headers=headers,
+            timeout=10,
+        )
+        response.raise_for_status()
+        data = response.json()
+        reply_text = data.get("response") or data.get("message") or ""
+        bot_msg = Message(username="UnderstandTech", content=reply_text)
+        messages.append(bot_msg)
+        return {"status": "ok", "response": reply_text}
+    except Exception as e:
+        return {"status": "error", "error": str(e)}


### PR DESCRIPTION
## Summary
- integrate UnderstandTech API into message endpoint
- add requests dependency and environment variable configuration

## Testing
- `python -m py_compile src/api/routes.py`
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_68a73fd6221883268e459224d4625925